### PR TITLE
Warning on AMD nodes

### DIFF
--- a/singularity/NEMO/README.md
+++ b/singularity/NEMO/README.md
@@ -1,0 +1,6 @@
+## AMD nodes: 
+
+These containers might not be compatible with the AMD nodes. I experienced MPI I/O Problems and segmentation faults (even in serial) that didn't arrise on the normal containers.
+
+To avoid AMD nodes even in the express queue, add the option `-l feature=intel`
+


### PR DESCRIPTION
@griessej @argreiner @annah2  do you agree with that or did you successfully use singularity on  AMD nodes ? 
Last time I tried was march.

You usually find out it is AMD because you have following message in your .o file: 
```
################################################################################
#                                                                              #
#            NEW AMD Rome test node with 128 real cores!                       #
#                                                                              #
#                              SMT is disabled!                                #
#                                                                              #
################################################################################
```