### PR TITLE
[ENH] added a python script to extract thermo output to Numpy format

### DIFF
--- a/LAMMPS_thermo/README.md
+++ b/LAMMPS_thermo/README.md
@@ -3,5 +3,6 @@ Any loose code snippets related to LAMMPS log files and thermo output.
 - `extract_thermo.sh`: Extracts thermo output from LAMMPS logs
 - `lmp_performance.regex`: A regular expression to extract performance 
   stats from LAMMPS logs and make them available via named capturing groups.
+- `log2npz.py`: Extracts **all** thermo outputs from LAMMPS logs to a Numpy file
 
 See file headers for usage samples.

--- a/LAMMPS_thermo/log2npz.py
+++ b/LAMMPS_thermo/log2npz.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import argparse
+
+from numpy import genfromtxt, savez_compressed
+
+
+__author__ = "Lucas Frerot"
+__email__ = "lucas.frerot@imtek.uni-freiburg.de"
+
+
+def get_line_nums(fp, regexp):
+    """Return line numbers matching regexp."""
+    return [num for num, line in enumerate(fp) if regexp.match(line)]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read LAMMPS log from STDIN and write numerical data to "
+        "STDOUT in compressed Numpy format (binary, one frame per array)"
+    )
+
+    parser.parse_args()
+
+    # Load whole log in memory
+    lines = sys.stdin.readlines()
+
+    # Compute start and end of individual frames
+    starts = get_line_nums(lines, re.compile("^Per MPI rank"))
+    ends = get_line_nums(lines, re.compile("^Loop time"))
+
+    # Sanity check on the number of frames, to avoid incomplete frames
+    assert len(starts) == len(ends),\
+        "Problem at start/end of frames"
+
+    # Construct frame list
+    frame_lines = map(lambda start, end: lines[start+1:end], starts, ends)
+
+    # Generate composed numpy array from data (dtype=None infers each col type)
+    frames = (genfromtxt(frame,
+                         names=True,
+                         dtype=None,
+                         encoding='utf-8',
+                         usemask=True) for frame in frame_lines)
+
+    # Write to stdout in compressed Numpy format (binary)
+    savez_compressed(sys.stdout.buffer, *frames)
+
+
+if __name__ == "__main__":
+    main()

--- a/LAMMPS_thermo/log2npz.py
+++ b/LAMMPS_thermo/log2npz.py
@@ -18,8 +18,22 @@ def get_line_nums(fp, regexp):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Read LAMMPS log from STDIN and write numerical data to "
-        "STDOUT in compressed Numpy format (binary, one frame per array)"
+        description=(
+            "Read LAMMPS log from STDIN and write numerical data to "
+            "STDOUT in compressed Numpy format (binary, one frame per array)"
+        ),
+        epilog=(
+            "Example usage:\n"
+            "\n"
+            "    ./log2npz.py < log.lammps > lammps_thermo_logz.npz\n"
+            "\n"
+            "How to use generated file:\n"
+            "\n"
+            "    # Loops over all the runs\n"
+            "    for thermo_data in np.load('lammps_thermo_logs.npz'):\n"
+            "        thermo_data['Temp'], thermo_data['PotEng'], ..."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     parser.parse_args()


### PR DESCRIPTION
The current bash script in the `LAMMPS_thermo` folder does not handle multiple thermo outputs. This new scripts writes to a Numpy archive, with each array (in order) being a full thermo output, with column headers and data type correctly set. It should also correctly handle missing data with masked arrays. It reads and write to/from standard io.